### PR TITLE
Admin dashboard alerts + CSP nonce wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,13 @@ AWS_USE_PATH_STYLE_ENDPOINT=false
 VITE_APP_NAME="${APP_NAME}"
 
 SENTRY_LARAVEL_DSN=
+
+# Content Security Policy (spatie/laravel-csp)
+# Set to false to disable CSP headers entirely
+CSP_ENABLED=true
+# Report violations to this URI without blocking (e.g. https://example.report-uri.com/r/d/csp/enforce)
+CSP_REPORT_URI=
+# Set to false to disable per-request nonce generation
+CSP_NONCE_ENABLED=true
+# Set to true if you need CSP headers even during Vite HMR (hot reloading); usually leave false
+CSP_ENABLED_WHILE_HOT_RELOADING=false

--- a/app/Csp/CloudflareCspPolicy.php
+++ b/app/Csp/CloudflareCspPolicy.php
@@ -3,30 +3,33 @@
 namespace App\Csp;
 
 use Spatie\Csp\Directive;
-use Spatie\Csp\Policies\Policy;
+use Spatie\Csp\Policy;
+use Spatie\Csp\Preset;
 
-class CloudflareCspPolicy extends Policy
+class CloudflareCspPolicy implements Preset
 {
-    public function configure()
+    public function configure(Policy $policy): void
     {
-        $this
-            ->addDirective(Directive::DEFAULT_SRC, ["'self'"])
-            ->addDirective(Directive::SCRIPT_SRC, [
+        $policy
+            ->add(Directive::DEFAULT_SRC, ["'self'"])
+            ->add(Directive::SCRIPT_SRC, [
                 "'self'",
-                "https://static.cloudflareinsights.com",
+                'https://static.cloudflareinsights.com',
             ])
-            ->addDirective(Directive::CONNECT_SRC, [
+            ->addNonce(Directive::SCRIPT_SRC)
+            ->add(Directive::CONNECT_SRC, [
                 "'self'",
-                "https://static.cloudflareinsights.com",
+                'https://static.cloudflareinsights.com',
             ])
-            ->addDirective(Directive::IMG_SRC, [
+            ->add(Directive::IMG_SRC, [
                 "'self'",
-                "https://static.cloudflareinsights.com",
+                'https://static.cloudflareinsights.com',
             ])
-            ->addDirective(Directive::STYLE_SRC, ["'self'"])
-            ->addDirective(Directive::OBJECT_SRC, ["'none'"])
-            ->addDirective(Directive::BASE_URI, ["'self'"])
-            ->addDirective(Directive::FRAME_ANCESTORS, ["'none'"])
-            ->addDirective(Directive::FORM_ACTION, ["'self'"]);
+            ->add(Directive::STYLE_SRC, ["'self'"])
+            ->addNonce(Directive::STYLE_SRC)
+            ->add(Directive::OBJECT_SRC, ["'none'"])
+            ->add(Directive::BASE_URI, ["'self'"])
+            ->add(Directive::FRAME_ANCESTORS, ["'none'"])
+            ->add(Directive::FORM_ACTION, ["'self'"]);
     }
 }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -2,30 +2,35 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\InviteCode;
+use App\Models\PassRequest;
+use App\Models\PromoCodeRepository;
 use App\Models\Season;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class DashboardController extends Controller
 {
+    private const LOW_PROMO_CODE_THRESHOLD = 10;
+
     /**
      * Display the dashboard or specific season view.
      */
     public function index(Request $request, $seasonId = null)
     {
+        $user = $request->user();
+
         if ($seasonId) {
             $season = Season::findOrFail($seasonId);
-            $user = $request->user();
 
-            if (!$user->isAdmin()) {
+            if (! $user->isAdmin()) {
                 $now = now();
                 $threeMonthsFromNow = $now->copy()->addMonths(3);
-                
+
                 $isActive = ($season->start_date <= $now && $season->final_deadline >= $now) ||
                             ($season->start_date > $now && $season->start_date <= $threeMonthsFromNow) ||
                             $season->passRequests()->where('user_id', $user->id)->exists();
 
-                if (!$isActive) {
+                if (! $isActive) {
                     abort(403, 'You do not have access to this season.');
                 }
             }
@@ -34,7 +39,63 @@ class DashboardController extends Controller
         return view('dashboard', [
             'seasonId' => $seasonId,
             'isQuestionsView' => $request->routeIs('questions.index'),
+            'adminData' => $user->isAdmin() ? $this->buildAdminDashboardData() : null,
         ]);
+    }
+
+    private function buildAdminDashboardData(): array
+    {
+        // Pass requests that have no promo code assigned yet, grouped by season
+        $unassignedRequests = PassRequest::whereNull('promo_code')
+            ->join('seasons', 'pass_requests.season_id', '=', 'seasons.id')
+            ->selectRaw('pass_requests.season_id, seasons.pass_name, seasons.pass_year, COUNT(*) as count')
+            ->groupBy('pass_requests.season_id', 'seasons.pass_name', 'seasons.pass_year')
+            ->get()
+            ->map(fn ($r) => [
+                'season_id' => $r->season_id,
+                'season_name' => $r->pass_name.' '.$r->pass_year,
+                'count' => (int) $r->count,
+            ])
+            ->values();
+
+        // Questions with no answer yet, grouped by season (filter >0 in PHP for SQLite compatibility)
+        $unansweredQuestions = Season::withCount(['questions' => fn ($q) => $q->whereNull('answered_at')])
+            ->get(['id', 'pass_name', 'pass_year'])
+            ->filter(fn ($s) => $s->questions_count > 0)
+            ->map(fn ($s) => [
+                'season_id' => $s->id,
+                'season_name' => $s->display_name,
+                'count' => (int) $s->questions_count,
+            ])
+            ->values();
+
+        // Available = non-suspended codes not yet used in any pass request
+        $availableCounts = PromoCodeRepository::where('is_suspended', false)
+            ->whereDoesntHave('passRequests')
+            ->selectRaw('season_id, COUNT(*) as available_count')
+            ->groupBy('season_id')
+            ->pluck('available_count', 'season_id');
+
+        // Only flag seasons that actually use the promo code repository
+        $seasonIdsWithCodes = PromoCodeRepository::query()
+            ->distinct()
+            ->pluck('season_id');
+
+        $lowPromoCodes = Season::whereIn('id', $seasonIdsWithCodes)
+            ->get(['id', 'pass_name', 'pass_year'])
+            ->filter(fn ($s) => ((int) ($availableCounts[$s->id] ?? 0)) <= self::LOW_PROMO_CODE_THRESHOLD)
+            ->map(fn ($s) => [
+                'season_id' => $s->id,
+                'season_name' => $s->display_name,
+                'available' => (int) ($availableCounts[$s->id] ?? 0),
+            ])
+            ->values();
+
+        return [
+            'unassigned_requests' => $unassignedRequests,
+            'unanswered_questions' => $unansweredQuestions,
+            'low_promo_codes' => $lowPromoCodes,
+        ];
     }
 
     /**
@@ -46,49 +107,49 @@ class DashboardController extends Controller
         $now = now();
         $startOfToday = $now->copy()->startOfDay();
         $threeMonthsFromNow = $now->copy()->addMonths(3);
-        
+
         // Get seasons with their pass requests for this user
         $query = Season::withCount(['passRequests' => function ($query) use ($user) {
             $query->where('user_id', $user->id);
         }])
-        ->withCount('questions')
-        ->with(['passRequests' => function ($query) use ($user) {
-            $query->where('user_id', $user->id)
-                  ->with('seasonPassType')
-                  ->orderBy('created_at', 'desc');
-        }]);
+            ->withCount('questions')
+            ->with(['passRequests' => function ($query) use ($user) {
+                $query->where('user_id', $user->id)
+                    ->with('seasonPassType')
+                    ->orderBy('created_at', 'desc');
+            }]);
 
         // If not admin, filter to active or relevant seasons
-        if (!$user->isAdmin()) {
+        if (! $user->isAdmin()) {
             $query->where(function ($query) use ($now, $startOfToday, $threeMonthsFromNow, $user) {
                 // Include if it's currently active (started and not finished)
                 // We use startOfDay for the deadline to be inclusive of the final day
                 $query->where(function ($q) use ($now, $startOfToday) {
                     $q->where('start_date', '<=', $now)
-                      ->where('final_deadline', '>=', $startOfToday);
+                        ->where('final_deadline', '>=', $startOfToday);
                 })
                 // OR if it's upcoming but within 3 months
-                ->orWhere(function ($q) use ($now, $threeMonthsFromNow) {
-                    $q->where('start_date', '>', $now)
-                      ->where('start_date', '<=', $threeMonthsFromNow);
-                })
+                    ->orWhere(function ($q) use ($now, $threeMonthsFromNow) {
+                        $q->where('start_date', '>', $now)
+                            ->where('start_date', '<=', $threeMonthsFromNow);
+                    })
                 // OR if the user has a pass request in it (even if it's old or too far)
-                ->orWhereHas('passRequests', function ($q) use ($user) {
-                    $q->where('user_id', $user->id);
-                })
+                    ->orWhereHas('passRequests', function ($q) use ($user) {
+                        $q->where('user_id', $user->id);
+                    })
                 // OR if the user has an invite code for this season
-                ->orWhereHas('inviteCodes', function ($q) use ($user) {
-                    $q->whereHas('users', function ($uq) use ($user) {
-                        $uq->where('users.id', $user->id);
+                    ->orWhereHas('inviteCodes', function ($q) use ($user) {
+                        $q->whereHas('users', function ($uq) use ($user) {
+                            $uq->where('users.id', $user->id);
+                        });
                     });
-                });
             });
         }
-        
+
         $seasons = $query->orderBy('pass_year', 'desc')
             ->orderBy('pass_name', 'asc')
             ->get();
-        
+
         return response()->json($seasons);
     }
 
@@ -101,9 +162,9 @@ class DashboardController extends Controller
             'invite_code' => ['required', 'string'],
         ]);
 
-        $inviteCode = \App\Models\InviteCode::where('invite_code', $validated['invite_code'])->first();
+        $inviteCode = InviteCode::where('invite_code', $validated['invite_code'])->first();
 
-        if (!$inviteCode) {
+        if (! $inviteCode) {
             return response()->json(['message' => 'Invalid invite code.'], 422);
         }
 
@@ -111,7 +172,7 @@ class DashboardController extends Controller
             return response()->json(['message' => 'This invite code is no longer active.'], 422);
         }
 
-        if (!$inviteCode->canBeUsed()) {
+        if (! $inviteCode->canBeUsed()) {
             return response()->json(['message' => 'This invite code has reached its maximum number of uses.'], 422);
         }
 
@@ -129,8 +190,8 @@ class DashboardController extends Controller
         $user->inviteCodes()->attach($inviteCode->id);
 
         return response()->json([
-            'message' => 'Invite code redeemed successfully! You now have access to ' . $inviteCode->season->display_name,
-            'season' => $inviteCode->season
+            'message' => 'Invite code redeemed successfully! You now have access to '.$inviteCode->season->display_name,
+            'season' => $inviteCode->season,
         ]);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,9 +6,10 @@ use App\Listeners\UpdateLastLoginDate;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
-use Symfony\Component\Mailer\Transport\Dsn;
-use Symfony\Component\Mailer\Bridge\Brevo\Transport\BrevoTransportFactory;
+use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\ServiceProvider;
+use Symfony\Component\Mailer\Bridge\Brevo\Transport\BrevoTransportFactory;
+use Symfony\Component\Mailer\Transport\Dsn;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -25,6 +26,11 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        // Propagate the per-request CSP nonce to all Vite-generated script/style tags
+        if (! $this->app->runningInConsole() && config('csp.nonce_enabled', true)) {
+            Vite::useCspNonce(app('csp-nonce'));
+        }
+
         // Register login event listener
         Event::listen(Login::class, UpdateLastLoginDate::class);
 
@@ -36,7 +42,7 @@ class AppServiceProvider extends ServiceProvider
         $this->app['mail.manager']->extend('brevo', function ($config) {
             $configuration = $this->app->make('config');
 
-            return (new BrevoTransportFactory())->create(
+            return (new BrevoTransportFactory)->create(
                 Dsn::fromString($configuration->get('services.brevo.dsn'))
             );
         });

--- a/config/csp.php
+++ b/config/csp.php
@@ -1,6 +1,50 @@
 <?php
 
 return [
-    'enabled' => true,
-    'policy' => App\Csp\CloudflareCspPolicy::class,
+
+    /*
+     * Presets configure which CSP directives are enforced. Leave empty while
+     * using report-only mode (see report_only_presets below).
+     */
+    'presets' => [],
+
+    'directives' => [],
+
+    /*
+     * Report-only mode: violations are reported but not blocked. Use this to
+     * validate the policy before switching to enforced mode.
+     */
+    'report_only_presets' => [
+        App\Csp\CloudflareCspPolicy::class,
+    ],
+
+    'report_only_directives' => [],
+
+    /*
+     * Violations will be reported to this URI (leave blank to disable).
+     */
+    'report_uri' => env('CSP_REPORT_URI', ''),
+
+    /*
+     * CSP headers are only added when this is true.
+     */
+    'enabled' => env('CSP_ENABLED', true),
+
+    /*
+     * Add CSP headers even when Vite HMR is active (hot reloading).
+     * Disabled by default because HMR uses inline scripts/websockets that
+     * would be blocked by a strict policy.
+     */
+    'enabled_while_hot_reloading' => env('CSP_ENABLED_WHILE_HOT_RELOADING', false),
+
+    /*
+     * Generator class for producing a per-request CSP nonce.
+     */
+    'nonce_generator' => Spatie\Csp\Nonce\RandomString::class,
+
+    /*
+     * Set to false to disable nonce generation (makes policy less secure).
+     */
+    'nonce_enabled' => env('CSP_NONCE_ENABLED', true),
+
 ];

--- a/resources/js/admin-dashboard.tsx
+++ b/resources/js/admin-dashboard.tsx
@@ -1,0 +1,106 @@
+import './bootstrap';
+
+import { AlertCircle, AlertTriangle, Ticket } from 'lucide-react';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+
+interface UnassignedRequest {
+  season_id: number;
+  season_name: string;
+  count: number;
+}
+
+interface UnansweredQuestion {
+  season_id: number;
+  season_name: string;
+  count: number;
+}
+
+interface LowPromoCode {
+  season_id: number;
+  season_name: string;
+  available: number;
+}
+
+interface AdminDashboardData {
+  unassigned_requests: UnassignedRequest[];
+  unanswered_questions: UnansweredQuestion[];
+  low_promo_codes: LowPromoCode[];
+}
+
+function AdminDashboard({ data }: { data: AdminDashboardData }) {
+  const hasAlerts =
+    data.unassigned_requests.length > 0 ||
+    data.unanswered_questions.length > 0 ||
+    data.low_promo_codes.length > 0;
+
+  if (!hasAlerts) return null;
+
+  return (
+    <div className="space-y-3 mb-6">
+      {data.unassigned_requests.map((item) => (
+        <Alert key={`unassigned-${item.season_id}`} variant="destructive">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>Unassigned pass requests — {item.season_name}</AlertTitle>
+          <AlertDescription className="flex items-center justify-between gap-4">
+            <span>
+              <strong>{item.count}</strong> pass {item.count === 1 ? 'request' : 'requests'}{' '}
+              {item.count === 1 ? 'has' : 'have'} no promo code assigned.
+            </span>
+            <Button asChild size="sm" variant="outline" className="shrink-0">
+              <a href={`/admin/seasons/${item.season_id}/pass-requests`}>View requests</a>
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ))}
+
+      {data.unanswered_questions.map((item) => (
+        <Alert key={`questions-${item.season_id}`}>
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Unanswered questions — {item.season_name}</AlertTitle>
+          <AlertDescription className="flex items-center justify-between gap-4">
+            <span>
+              <strong>{item.count}</strong> unanswered{' '}
+              {item.count === 1 ? 'question' : 'questions'} waiting for a response.
+            </span>
+            <Button asChild size="sm" variant="outline" className="shrink-0">
+              <a href={`/season/${item.season_id}/questions`}>View questions</a>
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ))}
+
+      {data.low_promo_codes.map((item) => (
+        <Alert key={`promo-${item.season_id}`}>
+          <Ticket className="h-4 w-4" />
+          <AlertTitle>Low promo code inventory — {item.season_name}</AlertTitle>
+          <AlertDescription className="flex items-center justify-between gap-4">
+            <span>
+              Only <strong>{item.available}</strong> unassigned promo{' '}
+              {item.available === 1 ? 'code' : 'codes'} remaining.
+            </span>
+            <Button asChild size="sm" variant="outline" className="shrink-0">
+              <a href={`/admin/seasons/${item.season_id}/promo-codes`}>View codes</a>
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ))}
+    </div>
+  );
+}
+
+const container = document.getElementById('admin-dashboard');
+if (container) {
+  const dataScript = document.getElementById('admin-dashboard-data');
+  if (dataScript) {
+    try {
+      const data: AdminDashboardData = JSON.parse(dataScript.textContent ?? '{}');
+      createRoot(container).render(<AdminDashboard data={data} />);
+    } catch (e) {
+      console.error('Failed to parse admin dashboard data', e);
+    }
+  }
+}

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -3,16 +3,24 @@
 @section('title', 'Dashboard')
 
 @section('content')
-  <div 
-    id="dashboard" 
-    data-user-name="{{ auth()->user()->name }}" 
+  <div
+    id="dashboard"
+    data-user-name="{{ auth()->user()->name }}"
     data-user-id="{{ auth()->id() }}"
     data-is-admin="{{ auth()->user()->isAdmin() ? '1' : '0' }}"
     data-season-id="{{ $seasonId ?? '' }}"
     data-is-questions-view="{{ ($isQuestionsView ?? false) ? '1' : '0' }}"
   ></div>
+
+  @if($adminData !== null)
+    <div id="admin-dashboard"></div>
+    <script id="admin-dashboard-data" type="application/json">{!! json_encode($adminData, JSON_HEX_TAG | JSON_HEX_AMP) !!}</script>
+  @endif
 @endsection
 
 @push('scripts')
   @vite(['resources/js/dashboard.tsx'])
+  @if($adminData !== null)
+    @vite(['resources/js/admin-dashboard.tsx'])
+  @endif
 @endpush

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -7,7 +7,7 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>@yield('title', config('app.name'))</title>
     <meta name="color-scheme" content="dark light">
-    <script>
+    <script @cspNonce>
       (function() {
         try {
           var theme = localStorage.getItem('theme') || 'system';
@@ -19,7 +19,7 @@
     </script>
     @vite(['resources/css/app.css', 'resources/js/navbar.tsx'])
     @if(config('sentry.dsn'))
-    <script>window.SENTRY_DSN = "{{ config('sentry.dsn') }}";</script>
+    <script @cspNonce>window.SENTRY_DSN = "{{ config('sentry.dsn') }}";</script>
     @vite(['resources/js/sentry.ts'])
     @endif
     @stack('head')
@@ -43,7 +43,7 @@
     @stack('scripts')
     <div id="sonner-toaster"></div>
     @vite(['resources/js/components/ui/sonner.tsx'])
-    <script>
+    <script @cspNonce>
       // This is a bit of a hack to ensure the Toaster is rendered
       // In a real app we'd probably have a top-level React provider
     </script>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
                 'resources/js/auth/register.tsx',
                 'resources/js/auth/forgot-password.tsx',
                 'resources/js/auth/reset-password.tsx',
+                'resources/js/admin-dashboard.tsx',
                 'resources/js/admin/invites.tsx',
                 'resources/js/admin/seasons/index.tsx',
                 'resources/js/admin/users.tsx',


### PR DESCRIPTION
## Summary

- **Admin-only alert panel** on the dashboard — rendered via a separate `admin-dashboard.tsx` Vite entrypoint so the code is never sent to non-admin users. Data is server-rendered into a `<script type="application/json" id="admin-dashboard-data">` block in the Blade template (no new API routes needed).
  - 🔴 **Unassigned pass requests** — flags any season where pass requests exist with no promo code set, with a link to the admin pass-requests page for that season
  - 🔵 **Unanswered questions** — flags seasons with unanswered Q&A, with a link to the questions view
  - 🎫 **Low promo code inventory** — flags seasons where ≤10 unassigned, non-suspended codes remain in the promo code repository, with a link to the promo codes admin page
- **CSP overhaul** — the previous config used the v2 API (`extends Policy` + `addDirective`) which is incompatible with spatie/laravel-csp v3; CSP headers were not being set at all. Fixed:
  - `CloudflareCspPolicy` converted to implement `Preset` with v3 `add()` API
  - `config/csp.php` updated to v3 `presets` / `report_only_presets` keys
  - Policy moved to **report-only mode** (violations are reported, not blocked) so it can be validated before enforcing
  - `@cspNonce` added to all inline `<script>` tags in `app.blade.php`
  - `Vite::useCspNonce()` wired in `AppServiceProvider` so all `@vite`-generated script/style tags carry the per-request nonce

## Test plan

- [x] `php artisan test` — 100 passed
- [x] `pnpm run type-check` — clean
- [x] `pnpm run build` — clean, `admin-dashboard-*.js` emitted
- [x] `./vendor/bin/pint --test` — clean after auto-fix

## TODO / Follow-up

- [ ] **Manually verify admin alerts render** in a browser with a real DB (need unassigned requests, unanswered questions, and/or a season with low promo codes to see each alert)
- [ ] **Switch CSP from report-only to enforced** once violations have been reviewed — change `report_only_presets` → `presets` in `config/csp.php`
- [ ] **Set `CSP_REPORT_URI`** in `.env` / hosting config to capture violation reports (e.g. via report-uri.com or a self-hosted endpoint)
- [ ] **Tune low-promo-code threshold** — currently hardcoded at `LOW_PROMO_CODE_THRESHOLD = 10` in `DashboardController`; consider making it configurable

🤖 Generated with [Claude Code](https://claude.com/claude-code)