### PR TITLE
Sanitize Q&A markdown rendering to prevent stored XSS

### DIFF
--- a/resources/js/components/Questions.tsx
+++ b/resources/js/components/Questions.tsx
@@ -217,7 +217,7 @@ export default function Questions({ seasonId, isAdmin, csrfToken }: QuestionsPro
                 <div className="flex flex-col">
                   <span className="text-sm font-medium text-primary mb-1">{question.user.name} asked:</span>
                   <div data-color-mode="auto">
-                    <MDEditor.Markdown source={question.content} />
+                    <MDEditor.Markdown source={question.content} skipHtml={true} />
                   </div>
                 </div>
                 <div className="flex flex-col items-center gap-2">
@@ -256,7 +256,7 @@ export default function Questions({ seasonId, isAdmin, csrfToken }: QuestionsPro
                     <div className="flex flex-col flex-1">
                       <span className="text-sm font-semibold mb-2">Answer from {question.answered_by?.name || 'Admin'}:</span>
                       <div data-color-mode="auto">
-                        <MDEditor.Markdown source={question.answer ?? ''} />
+                        <MDEditor.Markdown source={question.answer ?? ''} skipHtml={true} />
                       </div>
                       {isAdmin && (
                         <ShadcnButton variant="ghost" size="sm" className="mt-4 self-start" onClick={() => {


### PR DESCRIPTION
### Motivation
- Prevent stored XSS introduced by rendering user-authored Markdown with a preview pipeline that allowed raw HTML execution when admins or other users view Q&A content.

### Description
- In `resources/js/components/Questions.tsx` disable raw-HTML parsing by adding `skipHtml={true}` to `MDEditor.Markdown` when rendering both `question.content` and `question.answer`.

### Testing
- Ran `pnpm type-check` which completed successfully.  
- Ran `pnpm lint` which completed successfully (reports only pre-existing warnings, no new errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f83cee288331ab89bf6d50e45a13)