### PR TITLE
Enable passkey login

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@sentry/browser": "^10.51.0",
     "@uiw/react-md-editor": "^4.1.0",
-    "bwh-auth": "https://github.com/bherila/auth/releases/download/bwh-auth-v0.1.2/bwh-auth-0.1.2.tgz",
+    "bwh-auth": "https://github.com/bherila/auth/releases/download/bwh-auth-v0.1.3/bwh-auth-0.1.3.tgz",
     "class-variance-authority": "^0.7.1",
     "classnames": "^2.5.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       bwh-auth:
-        specifier: https://github.com/bherila/auth/releases/download/bwh-auth-v0.1.2/bwh-auth-0.1.2.tgz
-        version: https://github.com/bherila/auth/releases/download/bwh-auth-v0.1.2/bwh-auth-0.1.2.tgz(@base-ui/react@1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(lucide-react@0.577.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: https://github.com/bherila/auth/releases/download/bwh-auth-v0.1.3/bwh-auth-0.1.3.tgz
+        version: https://github.com/bherila/auth/releases/download/bwh-auth-v0.1.3/bwh-auth-0.1.3.tgz(@base-ui/react@1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(lucide-react@0.577.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2284,9 +2284,9 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
-  bwh-auth@https://github.com/bherila/auth/releases/download/bwh-auth-v0.1.2/bwh-auth-0.1.2.tgz:
-    resolution: {tarball: https://github.com/bherila/auth/releases/download/bwh-auth-v0.1.2/bwh-auth-0.1.2.tgz}
-    version: 0.1.2
+  bwh-auth@https://github.com/bherila/auth/releases/download/bwh-auth-v0.1.3/bwh-auth-0.1.3.tgz:
+    resolution: {tarball: https://github.com/bherila/auth/releases/download/bwh-auth-v0.1.3/bwh-auth-0.1.3.tgz}
+    version: 0.1.3
     peerDependencies:
       '@base-ui/react': ^1.4.1
       lucide-react: '>=0.468.0 <1.0.0'
@@ -6937,7 +6937,7 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
-  bwh-auth@https://github.com/bherila/auth/releases/download/bwh-auth-v0.1.2/bwh-auth-0.1.2.tgz(@base-ui/react@1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(lucide-react@0.577.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  bwh-auth@https://github.com/bherila/auth/releases/download/bwh-auth-v0.1.3/bwh-auth-0.1.3.tgz(@base-ui/react@1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(lucide-react@0.577.0(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@base-ui/react': 1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       lucide-react: 0.577.0(react@19.2.5)

--- a/resources/js/auth/login.tsx
+++ b/resources/js/auth/login.tsx
@@ -1,12 +1,15 @@
 import '../bootstrap';
 
-import React, { useState } from 'react';
+import { authenticateWithPasskey, isAbortError, isConditionalMediationAvailable, PasskeyLoginButton } from 'bwh-auth';
+import React, { useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+
+import { getCsrfToken } from './shared-components';
 
 function LoginForm() {
   const mount = document.getElementById('login');
@@ -18,6 +21,44 @@ function LoginForm() {
   const [remember, setRemember] = useState(false);
   const [errors, setErrors] = useState<Record<string, string[]>>(serverErrors);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [passkeyError, setPasskeyError] = useState<string | null>(null);
+  const [conditionalPasskeyAvailable, setConditionalPasskeyAvailable] = useState(false);
+  const passkeyEndpoints = useMemo(() => ({ csrfToken: getCsrfToken() }), []);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    let active = true;
+
+    async function startConditionalPasskeyLogin() {
+      const available = await isConditionalMediationAvailable();
+      if (!available || !active) return;
+
+      setConditionalPasskeyAvailable(true);
+
+      try {
+        const { redirectUrl } = await authenticateWithPasskey({
+          endpoints: passkeyEndpoints,
+          mediation: 'conditional',
+          signal: abortController.signal,
+        });
+
+        if (active) {
+          window.location.assign(redirectUrl);
+        }
+      } catch (error) {
+        if (!isAbortError(error) && active) {
+          setConditionalPasskeyAvailable(false);
+        }
+      }
+    }
+
+    void startConditionalPasskeyLogin();
+
+    return () => {
+      active = false;
+      abortController.abort();
+    };
+  }, [passkeyEndpoints]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -50,7 +91,7 @@ function LoginForm() {
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   required
-                  autoComplete="email"
+                  autoComplete={conditionalPasskeyAvailable ? 'username webauthn' : 'email'}
                   aria-invalid={!!errors.email}
                 />
                 {errors.email && (
@@ -96,6 +137,27 @@ function LoginForm() {
               <Button type="submit" className="w-full" disabled={isSubmitting}>
                 {isSubmitting ? 'Signing in...' : 'Sign In'}
               </Button>
+
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center">
+                  <span className="w-full border-t" />
+                </div>
+                <div className="relative flex justify-center text-xs uppercase">
+                  <span className="bg-card px-2 text-muted-foreground">Or continue with</span>
+                </div>
+              </div>
+
+              <PasskeyLoginButton
+                components={{ Button }}
+                endpoints={passkeyEndpoints}
+                className="w-full"
+                onError={(message) => setPasskeyError(message)}
+                onSuccess={(redirectUrl) => window.location.assign(redirectUrl)}
+              />
+
+              {passkeyError && (
+                <p className="text-sm text-destructive">{passkeyError}</p>
+              )}
             </div>
           </form>
           


### PR DESCRIPTION
## Summary

- Bumps `bwh-auth` to v0.1.4 from the GitHub release tarball.
- Bumps `bherila/auth-laravel` to v0.1.2.
- Adds explicit passkey sign-in to the SPGP login page.
- Enables WebAuthn conditional UI/autofill on the email field with `autocomplete="username webauthn"` when supported.
- Adds passwordless signup: users can opt to create an account with a passkey instead of entering a password.
- Refreshes Composer and pnpm dependency locks.

## Passkey login fix

`bherila/auth-laravel` v0.1.2 fixes the production passkey login failure:

> `WebAuthnService::credentialToSource(): Return value must be of type Webauthn\PublicKeyCredentialSource, Webauthn\CredentialRecord returned`

The package now uses `Webauthn\CredentialRecord`, which is the v5.3+ `web-auth/webauthn-lib` API expected by `AuthenticatorAssertionResponseValidator`.

## Notes

Password login remains a native Laravel form submit so existing session handling and validation behavior stay unchanged. Passkey login uses the shared Laravel auth package endpoints:

- `POST /api/passkeys/auth/options`
- `POST /api/passkeys/auth`

Passwordless signup is still owned by SPGP because invite code validation is app-specific. When `passwordless=1`, SPGP creates the user with a long random hashed password, logs the user in, returns JSON, and the React signup flow immediately launches shared passkey registration through the package endpoints:

- `POST /api/passkeys/register/options`
- `POST /api/passkeys/register`

Auth UI release: https://github.com/bherila/auth/releases/tag/bwh-auth-v0.1.4
Laravel auth tag: https://github.com/bherila/auth/releases/tag/v0.1.2

## Password reset / passkey behavior

A normal password reset should not automatically delete passkeys. Passkeys are independent credentials; users should receive reset/change notices and be able to review or revoke passkeys after reset. If the reset is part of a suspected compromise or formal account recovery flow, that separate flow can explicitly revoke sessions and passkeys.

## Validation

- `php -l /Users/bwh/proj/auth/laravel/src/Services/WebAuthnService.php`
- `composer update`
- `pnpm update`
- `pnpm --dir /Users/bwh/proj/spgp-laravel type-check`
- `pnpm --dir /Users/bwh/proj/spgp-laravel lint` (passes with existing hook dependency warnings)
- `pnpm --dir /Users/bwh/proj/spgp-laravel build`
- `php artisan test` (101 passed, 248 assertions)
