### PR TITLE
Fix pnpm 11 install config

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,7 +50,7 @@
 - **Clipboard API**: `navigator.clipboard` is only available in secure contexts. Always guard with `if (navigator.clipboard) { ... }`.
 - **Promo Code Auto-Assign**: `PromoCodeRepositoryController::autoAssign()` assigns codes oldest-request-first per country. Null-country requests are treated as USA. After auto-assign, the frontend auto-selects newly assigned rows using a before/after snapshot of `assign_code_date`.
 - **CI / GitHub Actions**:
-  - Canonical action versions: `actions/checkout@v5`, `actions/cache@v4`, `shivammathur/setup-php@v2`, `pnpm/action-setup@v4`. Use these everywhere — do not mix versions across jobs in the same file.
+  - Canonical action versions: `actions/checkout@v5`, `actions/cache@v4`, `shivammathur/setup-php@v2`, `pnpm/action-setup@v5`. Use these everywhere — do not mix versions across jobs in the same file.
   - Always add new PHP dev packages via `composer require --dev <package>` so `composer.lock` stays in sync. Never edit `composer.json` directly and skip `composer update`.
   - Parallel install pattern: launch both installs with `&`, capture PIDs, `wait` each individually, then assert both exit codes — bare `wait` masks background-process failures.
   - `shivammathur/setup-php` should always include `coverage: none` in CI (skips Xdebug setup, ~15 s faster). Only omit when coverage reporting is needed.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,8 +32,6 @@ jobs:
           
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
-        with:
-          version: 11
 
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -31,9 +31,9 @@ jobs:
           cp .env.example .env && php artisan key:generate
           
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
-          version: 10
+          version: 11
 
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,13 +18,13 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.5'
           coverage: none
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
-          version: 10
+          version: 11
 
       - name: Cache composer dependencies
         uses: actions/cache@v4
@@ -78,15 +78,15 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.5'
 
       - name: Install Composer (no dev)
         run: composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
-          version: 10
+          version: 11
 
       - name: Build frontend
         run: |
@@ -121,4 +121,4 @@ jobs:
         run: |
           sshpass -p "${{ secrets.SSH_PASSWORD }}" ssh -o StrictHostKeyChecking=no \
             ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }} \
-            "cd ~/laravel-spgp && /opt/cpanel/ea-php83/root/usr/bin/php artisan config:clear && /opt/cpanel/ea-php83/root/usr/bin/php artisan config:cache && /opt/cpanel/ea-php83/root/usr/bin/php artisan migrate --force && cd ~ && rm -rf spgp.vxcv.com && rm -rf web && ln -s laravel-spgp/public spgp.vxcv.com && ln -s laravel-spgp/public web"
+            "cd ~/laravel-spgp && /opt/cpanel/ea-php85/root/usr/bin/php artisan config:clear && /opt/cpanel/ea-php85/root/usr/bin/php artisan config:cache && /opt/cpanel/ea-php85/root/usr/bin/php artisan migrate --force && cd ~ && rm -rf spgp.vxcv.com && rm -rf web && ln -s laravel-spgp/public spgp.vxcv.com && ln -s laravel-spgp/public web"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
-        with:
-          version: 11
 
       - name: Cache composer dependencies
         uses: actions/cache@v4
@@ -85,8 +83,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
-        with:
-          version: 11
 
       - name: Build frontend
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,13 +16,13 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.5'
           coverage: none
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
-          version: 10
+          version: 11
 
       - name: Cache composer dependencies
         uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
-        with:
-          version: 11
 
       - name: Cache composer dependencies
         uses: actions/cache@v4

--- a/htaccess-append.txt
+++ b/htaccess-append.txt
@@ -1,7 +1,7 @@
 
 # php -- BEGIN cPanel-generated handler, do not edit
-# Set the “ea-php83” package as the default “PHP” programming language.
+# Set the “ea-php85” package as the default “PHP” programming language.
 <IfModule mime_module>
-  AddHandler application/x-httpd-ea-php83 .php .php8 .phtml
+  AddHandler application/x-httpd-ea-php85 .php .php8 .phtml
 </IfModule>
 # php -- END cPanel-generated handler, do not edit

--- a/package.json
+++ b/package.json
@@ -10,11 +10,6 @@
     "lint:fix": "eslint . --fix",
     "type-check": "tsc --noEmit"
   },
-  "pnpm": {
-    "overrides": {
-      "glob": ">=10.5.0"
-    }
-  },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@jest/types": "^30.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
+  "packageManager": "pnpm@11.5.0",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2285,7 +2285,7 @@ packages:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
   bwh-auth@https://github.com/bherila/auth/releases/download/bwh-auth-v0.1.4/bwh-auth-0.1.4.tgz:
-    resolution: {tarball: https://github.com/bherila/auth/releases/download/bwh-auth-v0.1.4/bwh-auth-0.1.4.tgz}
+    resolution: {tarball: https://github.com/bherila/auth/releases/download/bwh-auth-v0.1.4/bwh-auth-0.1.4.tgz, integrity: sha512-4StoO+PWocVd150AefcHECJitpUCyP8OusMZMjwcCrHFfwkr82FhPMVfNPWSFNvyYX6MKAdzH2lXHZf0Hoxt+Q==}
     version: 0.1.4
     peerDependencies:
       '@base-ui/react': ^1.4.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,9 @@
 overrides:
   glob: '>=10.5.0'
 
+minimumReleaseAgeExclude:
+  - bwh-auth
+
 onlyBuiltDependencies:
   - '@swc/core'
   - esbuild

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,12 @@
+overrides:
+  glob: '>=10.5.0'
+
+onlyBuiltDependencies:
+  - '@swc/core'
+  - esbuild
+  - unrs-resolver
+
+allowBuilds:
+  '@swc/core': true
+  esbuild: true
+  unrs-resolver: true


### PR DESCRIPTION
## Summary
- move the pnpm glob override into pnpm-workspace.yaml so pnpm 11 applies it
- allow the project build dependencies that pnpm reports during install
- pin the repo package manager to pnpm 11.5.0 and upgrade GitHub Actions pnpm setup to v5 / pnpm 11
- run GitHub Actions PHP jobs on PHP 8.5
- switch production htaccess and remote artisan commands from ea-php83 to ea-php85
- add bwh-auth to the pnpm minimum release age exclusion and record tarball integrity for pnpm 11 frozen installs

## Validation
- pnpm install --frozen-lockfile
- pnpm test
- pnpm build
- workflow YAML parse check
- composer install
- php artisan test