### PR TITLE
Upgrade bherila/auth-laravel to v0.4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "bherila/auth-laravel": "^0.3",
+        "bherila/auth-laravel": "^0.4",
         "erusev/parsedown": "^1.7",
         "laravel/framework": "^13.0",
         "laravel/tinker": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a79a1b54edb3e647d69ca8a3e137db02",
+    "content-hash": "179d624181cba0ea7af629fc811709c2",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -159,16 +159,16 @@
         },
         {
             "name": "bherila/auth-laravel",
-            "version": "v0.3.0",
+            "version": "v0.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bherila/auth.git",
-                "reference": "1b66d3e74c354e8cbe3aca3a1edc54cbf9d110aa"
+                "reference": "a7d6db179b6c6c6786b370e3aab651ae5627dddf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bherila/auth/zipball/1b66d3e74c354e8cbe3aca3a1edc54cbf9d110aa",
-                "reference": "1b66d3e74c354e8cbe3aca3a1edc54cbf9d110aa",
+                "url": "https://api.github.com/repos/bherila/auth/zipball/a7d6db179b6c6c6786b370e3aab651ae5627dddf",
+                "reference": "a7d6db179b6c6c6786b370e3aab651ae5627dddf",
                 "shasum": ""
             },
             "require": {
@@ -217,10 +217,10 @@
             ],
             "description": "Shared Laravel authentication services for BWH applications.",
             "support": {
-                "source": "https://github.com/bherila/auth/tree/v0.3.0",
+                "source": "https://github.com/bherila/auth/tree/v0.4.1",
                 "issues": "https://github.com/bherila/auth/issues"
             },
-            "time": "2026-06-04T03:54:48+00:00"
+            "time": "2026-06-06T00:02:55+00:00"
         },
         {
             "name": "brick/math",

--- a/config/bherila-auth.php
+++ b/config/bherila-auth.php
@@ -24,6 +24,16 @@ return [
         'admin_ability' => env('BHERILA_AUTH_AUDIT_ADMIN_ABILITY'),
     ],
 
+    'throttle' => [
+        // Opt-in brute-force lockout backed by auth_audit_log rows. Disabled by default.
+        'enabled' => env('BHERILA_AUTH_THROTTLE_ENABLED', false),
+        'max_attempts' => env('BHERILA_AUTH_THROTTLE_MAX_ATTEMPTS', 5),
+        'decay_minutes' => env('BHERILA_AUTH_THROTTLE_DECAY_MINUTES', 15),
+        // email, ip, or email_ip. Invalid values fall back to email_ip.
+        'key' => env('BHERILA_AUTH_THROTTLE_KEY', 'email_ip'),
+        'record_blocked' => env('BHERILA_AUTH_THROTTLE_RECORD_BLOCKED', true),
+    ],
+
     'password_resets' => [
         'reset_url' => env('BHERILA_AUTH_PASSWORD_RESET_URL', env('APP_URL', '').'/reset-password/{token}?email={email}'),
         'request_url' => env('BHERILA_AUTH_PASSWORD_REQUEST_URL', '/forgot-password'),


### PR DESCRIPTION
## Summary
- Bumps `bherila/auth-laravel` from `^0.3` to `^0.4` and locks v0.4.1.
- Adds the new published `bherila-auth.throttle` config block with lockout disabled by default.
- Leaves `bwh-auth` UI package unchanged because the auth release did not change UI assets.

Auth release: https://github.com/bherila/auth/releases/tag/v0.4.1

## Validation
- `php -l config/bherila-auth.php`
- `pnpm install --frozen-lockfile --prefer-offline`
- `pnpm run build`
- `composer test` exited successfully (`2 passed`, `110 warnings`, `303 assertions`)

Note: the warning-only tests report existing `file_get_contents(...)` warnings while still exiting successfully; this was not introduced by the auth dependency bump.
