### PR TITLE
chore(deps): upgrade bherila/auth-laravel to v0.4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "bherila/auth-laravel": "^0.3",
+        "bherila/auth-laravel": "^0.4",
         "erusev/parsedown": "^1.7",
         "laravel/framework": "^13.0",
         "laravel/tinker": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a79a1b54edb3e647d69ca8a3e137db02",
+    "content-hash": "179d624181cba0ea7af629fc811709c2",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -159,16 +159,16 @@
         },
         {
             "name": "bherila/auth-laravel",
-            "version": "v0.3.0",
+            "version": "v0.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bherila/auth.git",
-                "reference": "1b66d3e74c354e8cbe3aca3a1edc54cbf9d110aa"
+                "reference": "da52cd9f9b9c9a05cbc09878ab4488f2a104431a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bherila/auth/zipball/1b66d3e74c354e8cbe3aca3a1edc54cbf9d110aa",
-                "reference": "1b66d3e74c354e8cbe3aca3a1edc54cbf9d110aa",
+                "url": "https://api.github.com/repos/bherila/auth/zipball/da52cd9f9b9c9a05cbc09878ab4488f2a104431a",
+                "reference": "da52cd9f9b9c9a05cbc09878ab4488f2a104431a",
                 "shasum": ""
             },
             "require": {
@@ -217,10 +217,10 @@
             ],
             "description": "Shared Laravel authentication services for BWH applications.",
             "support": {
-                "source": "https://github.com/bherila/auth/tree/v0.3.0",
+                "source": "https://github.com/bherila/auth/tree/v0.4.2",
                 "issues": "https://github.com/bherila/auth/issues"
             },
-            "time": "2026-06-04T03:54:48+00:00"
+            "time": "2026-06-07T00:57:00+00:00"
         },
         {
             "name": "brick/math",
@@ -11175,15 +11175,15 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.3.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Summary

Catch-up upgrade of `bherila/auth-laravel` to **v0.4.2**, bumping the constraint from `^0.3` to `^0.4` in `composer.json`. This spans the audit-log / passkey / 2FA / throttle additions made since 0.1.2.

spgp-laravel does **not** use the new throttle / read-endpoint / passkey-2FA features yet — this PR is the dependency catch-up only. Feature adoption (binding the package audit logger, throttle, repointing readers, prune schedule, etc.) is intentionally left for follow-up work.

## Changes

- `composer.json`: `bherila/auth-laravel` `^0.3` → `^0.4`
- `composer.lock`: resolved to `v0.4.2`

## Breaking-change review

- **Contract:** spgp does not implement `BWH\Auth\Contracts\AuthAuditLogger`, so the default package binding applies — no contract migration needed. The new `AbstractAuthAuditLogger` resolves correctly if adoption is desired later.
- **Migrations:** `php artisan migrate` applies all intervening migrations cleanly. The package's `auth_audit_log` migration no-ops via its `Schema::hasTable()` guard against spgp's pre-existing audit-log table.
- **Config:** the app-owned `config/bherila-auth.php` is left intact. The new `throttle` / `read_endpoints` keys default to disabled and are unused here, so the missing keys are harmless.

## Verification

- `composer update bherila/auth-laravel` → resolves to `v0.4.2`
- `php artisan migrate` (sqlite) → all migrations DONE, no errors
- `php artisan test` → green (2 passed, 0 failures, 303 assertions). The 110 deprecation notices are the pre-existing `PDO::MYSQL_ATTR_SSL_CA` PHP 8.5 deprecation in `config/database.php`, unrelated to this change.
- Auth smoke: `login` route + all `BWH\Auth\*` package routes register; consumed symbols (`AuthAuditLog`, `LogsAuthEvents`, `ClientIp`, `AbstractAuthAuditLogger`) resolve; `config('bherila-auth')` loads. No class-not-found.
- `pint --dirty` → passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)