### PR TITLE
Harden deploy workflow SSH authentication and host verification

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,7 +14,10 @@ Once the `prod` environment is created, you need to configure the following secr
 2.  `SSH_USERNAME`: The username for SSH login.
     -   Example: `your_user`
 
-3.  `SSH_PASSWORD`: The password for the SSH user.
+3.  `SSH_PRIVATE_KEY`: A dedicated private SSH key for the deployment user (preferably Ed25519).
+
+4.  `SSH_KNOWN_HOSTS`: The pinned host key entry for the deployment host (same format as `~/.ssh/known_hosts`).
+    -   Example generation from a trusted machine: `ssh-keyscan -H your.server.com`
 
 ## Deployment Target
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,13 +96,18 @@ jobs:
       - name: Append to .htaccess
         run: cat htaccess-append.txt >> public/.htaccess
 
-      - name: Install sshpass
-        run: sudo apt-get install -y sshpass
+      - name: Configure SSH
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          printf '%s\n' "${{ secrets.SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
 
       - name: Deploy with rsync
         run: |
-          sshpass -p "${{ secrets.SSH_PASSWORD }}" rsync -av --delete --exclude='.env' \
-            -e "ssh -o StrictHostKeyChecking=no" \
+          rsync -av --delete --exclude='.env' \
+            -e "ssh -o StrictHostKeyChecking=yes" \
             app \
             bootstrap \
             config \
@@ -119,6 +124,6 @@ jobs:
 
       - name: Run artisan config clear/cache on server
         run: |
-          sshpass -p "${{ secrets.SSH_PASSWORD }}" ssh -o StrictHostKeyChecking=no \
+          ssh -o StrictHostKeyChecking=yes \
             ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }} \
             "cd ~/laravel-spgp && /opt/cpanel/ea-php83/root/usr/bin/php artisan config:clear && /opt/cpanel/ea-php83/root/usr/bin/php artisan config:cache && /opt/cpanel/ea-php83/root/usr/bin/php artisan migrate --force && cd ~ && rm -rf spgp.vxcv.com && rm -rf web && ln -s laravel-spgp/public spgp.vxcv.com && ln -s laravel-spgp/public web"


### PR DESCRIPTION
### Motivation
- The production deploy workflow used password-based SSH with `sshpass` and `StrictHostKeyChecking=no`, allowing an attacker who can MITM DNS/traffic to capture deployment credentials and compromise deployments.
- Replace password auth and disabled host verification with pinned host keys and a dedicated deploy key to prevent credential exfiltration and MITM impersonation.

### Description
- Replaced the `sshpass` installation and password-based `rsync`/`ssh` usage in `.github/workflows/deploy.yml` with an SSH setup step that writes a private key from `secrets.SSH_PRIVATE_KEY` to `~/.ssh/id_ed25519` and writes pinned host keys from `secrets.SSH_KNOWN_HOSTS` to `~/.ssh/known_hosts`.
- Enforced `StrictHostKeyChecking=yes` for the `rsync` and remote `ssh` steps so SSH host verification is required.
- Removed calls that supplied `secrets.SSH_PASSWORD` to `sshpass` and removed installation of `sshpass`.
- Updated `.github/workflows/README.md` to require `SSH_PRIVATE_KEY` and `SSH_KNOWN_HOSTS` environment secrets (with guidance to generate a host key entry via `ssh-keyscan -H`).

### Testing
- No automated test changes were made; the repository CI `test` job remains unchanged and will run on the branch/PR.
- The workflow file edits were validated by inspecting the updated `.github/workflows/deploy.yml` and `.github/workflows/README.md` diffs and committing the changes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2fcc248c88331a4fdb4809d1b7762)