### PR TITLE
Restore CSRF validation for session-authenticated API routes

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -13,9 +13,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        $middleware->validateCsrfTokens(except: [
-            'api/*',
-        ]);
+        // Use default CSRF validation for session-authenticated routes.
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         Integration::handles($exceptions);


### PR DESCRIPTION
### Motivation
- Re-enable CSRF protection because `bootstrap/app.php` previously exempted `api/*` while those endpoints run with session-based `web`+`auth` middleware and include sensitive admin mutations, creating a CSRF risk.

### Description
- Removed the `validateCsrfTokens(except: ['api/*'])` exemption and reverted to default CSRF validation in `bootstrap/app.php` so `/api/*` routes that rely on browser sessions require CSRF tokens.

### Testing
- Ran `pnpm type-check` successfully; `php artisan test` could not run in this environment due to missing `vendor/autoload.php` (dependencies not installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2fb7f9db883319e4e8a343ed0b1cc)