### PR TITLE
Sanitize admin TSV clipboard export to prevent spreadsheet injection

### DIFF
--- a/resources/js/admin/season-pass-requests.tsx
+++ b/resources/js/admin/season-pass-requests.tsx
@@ -268,6 +268,11 @@ function SeasonPassRequestsAdmin() {
       new Set(filteredRequests.filter((r) => r.promo_code && !r.email_notify_time).map((r) => r.id)),
     );
 
+  const escapeTSVCell = (value: string | null | undefined) => {
+    const normalized = String(value ?? '').replace(/[\t\r\n]+/g, ' ');
+    return /^[=+\-@\t\r\n]/.test(normalized) ? `'${normalized}` : normalized;
+  };
+
   const handleCopyTSV = async () => {
     // Sort selected requests oldest-first (by created_at asc) for Excel paste appending
     const selectedRequests = passRequests
@@ -283,7 +288,7 @@ function SeasonPassRequestsAdmin() {
       getAgeGroup(r.passholder_birth_date),
       r.promo_code ?? '',
     ]);
-    const tsv = rows.map((row) => row.join('\t')).join('\n');
+    const tsv = rows.map((row) => row.map((cell) => escapeTSVCell(cell)).join('\t')).join('\n');
     try {
       await navigator.clipboard.writeText(tsv);
       setActionMessage(`Copied ${selectedRequests.length} row${selectedRequests.length !== 1 ? 's' : ''} to clipboard as TSV.`);


### PR DESCRIPTION
### Motivation
- The admin "Copy TSV" path was serializing raw, attacker-controlled passholder and promo fields into clipboard TSV, which can trigger spreadsheet formula execution and row/column injection when pasted into Excel/Google Sheets.
- The intent of the change is to harden the TSV export step with minimal, focused escaping so admins can keep using the clipboard export safely.

### Description
- Add `escapeTSVCell` in `resources/js/admin/season-pass-requests.tsx` to normalize embedded tabs/newlines/carriage-returns to spaces and to neutralize formula-leading characters by prefixing with an apostrophe. 
- Apply `escapeTSVCell` to every exported cell before joining rows into the TSV output. 
- Preserve the existing sort order, selected-row behavior, clipboard write, and success/error messages.

### Testing
- Ran `pnpm type-check` and the TypeScript check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f7b1682483318f68d9e707ef6290)