### PR TITLE
Sanitize admin users TSV export to prevent spreadsheet formula injection

### DIFF
--- a/resources/js/admin/users.tsx
+++ b/resources/js/admin/users.tsx
@@ -90,15 +90,27 @@ function AdminUsers() {
     fetchUsers();
   }, []);
 
+
+  const sanitizeTSVCell = (value: string | number) => {
+    const normalized = String(value).replace(/[\t\n\r]/g, ' ');
+    return /^[=+\-@]/.test(normalized) ? `'${normalized}` : normalized;
+  };
+
   const handleCopyTSV = async () => {
+    if (!navigator.clipboard) {
+      setError('Clipboard is not available in this browser context.');
+      return;
+    }
+
     const header = ['ID', 'EMAIL', 'FIRSTNAME', 'LASTNAME'].join('\t');
     const rows = users.map((u) => [
-      u.id,
-      u.email,
-      u.first_name ?? '',
-      u.last_name ?? '',
+      sanitizeTSVCell(u.id),
+      sanitizeTSVCell(u.email),
+      sanitizeTSVCell(u.first_name ?? ''),
+      sanitizeTSVCell(u.last_name ?? ''),
     ].join('\t'));
     const tsv = [header, ...rows].join('\n');
+
     try {
       await navigator.clipboard.writeText(tsv);
       setActionMessage(`Copied ${users.length} user${users.length !== 1 ? 's' : ''} to clipboard as TSV.`);


### PR DESCRIPTION
### Motivation
- The admin "Copy TSV" feature built clipboard TSV by joining user-controlled fields directly, allowing attacker-controlled names to become spreadsheet formulas when pasted into Excel/Sheets.  
- That can lead to remote data exfiltration or other harmful actions when an admin pastes the exported TSV into a spreadsheet.  
- The change aims to neutralize formula-leading characters and embedded delimiters on export without changing backend registration behavior.

### Description
- Added a `sanitizeTSVCell` helper in `resources/js/admin/users.tsx` that replaces `\t`, `\n`, and `\r` with spaces and prefixes values starting with `=`, `+`, `-`, or `@` with a single quote to neutralize spreadsheet formulas.  
- Updated `handleCopyTSV` to call `sanitizeTSVCell` for every exported field (`id`, `email`, `first_name`, `last_name`) while keeping the existing TSV header and layout.  
- Added a guard to check `navigator.clipboard` availability before attempting `navigator.clipboard.writeText`, following the repo's clipboard API guidance.  
- Change is limited to `resources/js/admin/users.tsx` and preserves existing UX messaging and TSV shape.

### Testing
- Ran `pnpm type-check` and the TypeScript check completed successfully.  
- No backend or other automated tests were modified; the fix is a minimal frontend sanitization to mitigate the spreadsheet injection sink.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f785f89883318c782b8c5150f49f)