### PR TITLE
Bump bherila/auth-laravel to v0.4.3 (2FA link host-header fix)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -159,16 +159,16 @@
         },
         {
             "name": "bherila/auth-laravel",
-            "version": "v0.4.2",
+            "version": "v0.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bherila/auth.git",
-                "reference": "da52cd9f9b9c9a05cbc09878ab4488f2a104431a"
+                "reference": "d2a78a33685f5e6b35c2b245d3ffc827c682bbb5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bherila/auth/zipball/da52cd9f9b9c9a05cbc09878ab4488f2a104431a",
-                "reference": "da52cd9f9b9c9a05cbc09878ab4488f2a104431a",
+                "url": "https://api.github.com/repos/bherila/auth/zipball/d2a78a33685f5e6b35c2b245d3ffc827c682bbb5",
+                "reference": "d2a78a33685f5e6b35c2b245d3ffc827c682bbb5",
                 "shasum": ""
             },
             "require": {
@@ -217,10 +217,10 @@
             ],
             "description": "Shared Laravel authentication services for BWH applications.",
             "support": {
-                "source": "https://github.com/bherila/auth/tree/v0.4.2",
+                "source": "https://github.com/bherila/auth/tree/v0.4.3",
                 "issues": "https://github.com/bherila/auth/issues"
             },
-            "time": "2026-06-07T00:57:00+00:00"
+            "time": "2026-06-08T05:54:47+00:00"
         },
         {
             "name": "brick/math",

--- a/tests/Feature/SharedAuthPackageTest.php
+++ b/tests/Feature/SharedAuthPackageTest.php
@@ -3,11 +3,15 @@
 namespace Tests\Feature;
 
 use App\Models\User;
+use BWH\Auth\Mail\TwoFactorLoginMail;
 use BWH\Auth\Models\AuthAuditLog;
 use BWH\Auth\Models\PasskeyCredential;
+use BWH\Auth\Services\TwoFactorService;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
@@ -56,6 +60,33 @@ class SharedAuthPackageTest extends TestCase
         $response->assertJsonPath('rp.id', 'spgp.example.test');
         $response->assertJsonPath('authenticatorSelection.residentKey', 'preferred');
         $response->assertJsonPath('authenticatorSelection.userVerification', 'preferred');
+    }
+
+    public function test_two_factor_email_links_use_app_url_not_spoofed_host(): void
+    {
+        // Regression guard for bherila/auth-laravel >= v0.4.3: the 2FA challenge
+        // email links must be rooted at app.url, never the (attacker-controllable)
+        // request Host header, to prevent host-header injection of the 2FA links.
+        config(['app.url' => 'https://spgp.example.test']);
+        Mail::fake();
+
+        $user = User::factory()->create();
+
+        // Simulate a login request carrying a spoofed Host header.
+        $request = Request::create('https://evil.example.com/login', 'POST');
+        $request->headers->set('Host', 'evil.example.com');
+        $request->setLaravelSession($this->app['session']->driver());
+
+        $this->app->make(TwoFactorService::class)->startChallenge($user, $request);
+
+        Mail::assertSent(TwoFactorLoginMail::class, function (TwoFactorLoginMail $mail): bool {
+            foreach ([$mail->confirmUrl, $mail->reportUrl] as $url) {
+                $this->assertStringStartsWith('https://spgp.example.test/', $url);
+                $this->assertStringNotContainsString('evil.example.com', $url);
+            }
+
+            return true;
+        });
     }
 
     public function test_user_login_redirect_policy_preserves_dashboard_destination(): void


### PR DESCRIPTION
## Summary
- Bumps `bherila/auth-laravel` v0.4.2 → **v0.4.3**, which roots the 2FA login-challenge email links (`confirm`/`report`) at `app.url` instead of the request host (bherila/auth#10), closing a host-header injection vector.
- Adds a regression test (`SharedAuthPackageTest::test_two_factor_email_links_use_app_url_not_spoofed_host`) that drives `TwoFactorService::startChallenge` with a spoofed `Host` header and asserts the emailed links use `app.url` and never the spoofed host.

## Testing
- `php artisan test tests/Feature/SharedAuthPackageTest.php` → 6 passed, 23 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)