### PR TITLE
chore(ci): bump actions/cache to v5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
         uses: pnpm/action-setup@v5
 
       - name: Cache composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: vendor
           key: composer-${{ hashFiles('composer.lock') }}
@@ -36,7 +36,7 @@ jobs:
         run: echo "store=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.store }}
           key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         uses: pnpm/action-setup@v5
 
       - name: Cache composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: vendor
           key: composer-${{ hashFiles('composer.lock') }}
@@ -34,7 +34,7 @@ jobs:
         run: echo "store=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.store }}
           key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}


### PR DESCRIPTION
Node.js 20 actions are deprecated; GitHub forces Node.js 24 by default starting June 16 2026. Bumps `actions/cache` from v4 → v5 in `deploy.yml` and `test.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)