### PR TITLE
chore: schedule bherila-auth:prune-audit-log daily (parity with uc-laravel)

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -2,7 +2,15 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+// ── Scheduler ────────────────────────────────────────────────────────────────
+Schedule::command('bherila-auth:prune-audit-log')
+    ->daily()
+    ->onOneServer()
+    ->withoutOverlapping()
+    ->runInBackground();


### PR DESCRIPTION
## Summary

- `config/bherila-auth.php` has `retention_days` wired, but `bherila-auth:prune-audit-log` was never added to the Laravel scheduler, so old audit-log rows accumulated indefinitely.
- Adds a daily schedule entry to `routes/console.php`, matching the pattern used in uc-laravel (which already schedules this command with `->daily()->onOneServer()->withoutOverlapping()->runInBackground()`).
- Also adds the required `use Illuminate\Support\Facades\Schedule;` import.

## Test plan

- [ ] Verify `php artisan schedule:list` shows `bherila-auth:prune-audit-log` running daily after merge.
- [ ] Confirm no functional changes to any other routes/commands.