### PR TITLE
harden artisan safety hook (segment-based parsing)

### DIFF
--- a/.claude/hooks/block-dangerous-artisan.sh
+++ b/.claude/hooks/block-dangerous-artisan.sh
@@ -7,17 +7,17 @@
 # so the agent can retry with the only permitted form:
 #   php artisan migrate --database=sqlite --no-interaction
 #
-# Design: normalize quotes, split the command into segments on shell separators
-# and redirections, then validate EACH artisan segment against its OWN flags.
-# Any migrate:* / schema:d* / db:wi* subcommand (including Symfony command-prefix
-# abbreviations such as migrate:ref, schema:du, db:wi) is treated as destructive
-# and always denied; only a plain `migrate` with --database=sqlite and
-# --no-interaction (and no conflicting --database) is allowed.
+# Design: join line continuations, normalize quotes, split into command segments
+# on shell separators, drop redirections (keeping the surviving args), then check
+# each artisan segment against its OWN flags. Destructive subcommands — migrate:*,
+# schema:dump, db:wipe, and Symfony namespace/command abbreviations of them
+# (migr:f, d:wi, schem:du, ...) — are always denied; only a plain `migrate` with
+# --database=sqlite --no-interaction (no conflicting --database) is allowed.
 #
-# This is defense-in-depth for a cooperative agent, not a sandbox: indirection
-# such as eval, base64, $(...), or env-var assembly can still reach the shell and
-# is intentionally out of scope — the documented rule + human oversight remain
-# the primary guard.
+# This is defense-in-depth for a cooperative agent, not a sandbox: runtime
+# indirection (eval, base64, $(...), env-var assembly) can still reach the shell
+# and is intentionally out of scope — the documented rule + human oversight
+# remain the primary guard.
 set -euo pipefail
 
 payload="$(cat || true)"
@@ -34,41 +34,57 @@ deny() {
   exit 0
 }
 
-# Bash strips quotes before argv reaches artisan; normalize them to spaces so
-# quoted forms ('migrate', --database "mysql") are seen the same as bare ones.
-norm="${command//\'/ }"
+# Join backslash-newline continuations (bash removes them before tokenizing),
+# then normalize quotes so 'migrate' / --database "mysql" are seen like bare forms.
+norm="${command//\\$'\n'/ }"
+norm="${norm//\'/ }"
 norm="${norm//\"/ }"
 
 verdict="$(printf '%s' "$norm" | awk '
   { all = all $0 "\n" }
   END {
-    # Split into command segments on shell separators / redirections / subshells
-    # so each artisan call is validated with only its own options.
+    # Segment on shell separators / subshells (NOT redirections — their trailing
+    # args still belong to the same command and must be validated).
     gsub(/\$\(/, "\n", all)
-    gsub(/[;|&<>()`]/, "\n", all)
+    gsub(/[;|&()`]/, "\n", all)
     nseg = split(all, segs, "\n")
 
     dest = 0; bad_migrate = 0; bad_schema = 0
 
     for (s = 1; s <= nseg; s++) {
       m = split(segs[s], tok, /[ \t]+/)
-      seen = 0; danger = ""; sqlite = 0; nonsqlite = 0; nointer = 0; prune = 0; expectdb = 0
+      seen = 0; danger = ""; sqlite = 0; nonsqlite = 0; nointer = 0; prune = 0
+      expectdb = 0; skipnext = 0
       for (i = 1; i <= m; i++) {
         t = tok[i]
         if (t == "") continue
+        if (skipnext) { skipnext = 0; continue }
+        # Redirections: drop the operator (and a detached target) but keep the rest.
+        if (t ~ /^[0-9]*(>>|<<|>|<)/) {
+          if (t ~ /^[0-9]*(>>|<<|>|<)$/) skipnext = 1
+          continue
+        }
         if (t == "artisan" || t ~ /\/artisan$/) { seen = 1; continue }
         if (!seen) continue
-        if (expectdb) { if (t == "sqlite") sqlite = 1; else nonsqlite = 1; expectdb = 0; continue }
+        # A bare `--database` expects a value, but if the next token is actually a
+        # dangerous subcommand, classify it instead of swallowing it as the value.
+        if (expectdb) {
+          expectdb = 0
+          if (!(t ~ /^mi[a-z]*:/ || t ~ /^d[a-z]*:w/ || t == "migrate" || t ~ /^sc[a-z]*:d/)) {
+            if (t == "sqlite") sqlite = 1; else nonsqlite = 1
+            continue
+          }
+        }
         if (t == "--no-interaction") { nointer = 1; continue }
         if (t == "--prune") { prune = 1; continue }
         if (t ~ /^--database=/) { v = substr(t, 12); if (v == "sqlite") sqlite = 1; else nonsqlite = 1; continue }
         if (t == "--database") { expectdb = 1; continue }
-        # Destructive: any migrate:* subcommand, or db:wipe (and its abbreviations).
-        if (t ~ /^migrate:/ || t ~ /^db:wi/) { danger = "dest"; continue }
-        # Plain migrate (the only form that can be allowed).
+        # Destructive: migrate namespace (migrate:* incl. abbrev migr:f) or db:wipe
+        # (incl. abbrev d:wi / db:w).
+        if (t ~ /^mi[a-z]*:/ || t ~ /^d[a-z]*:w/) { danger = "dest"; continue }
         if (t == "migrate") { if (danger == "") danger = "migrate"; continue }
-        # schema:dump and its abbreviations (schema:d, schema:du, ...).
-        if (t ~ /^schema:d/) { if (danger == "") danger = "schema"; continue }
+        # schema:dump and its abbreviations (schem:du, schema:d, ...).
+        if (t ~ /^sc[a-z]*:d/) { if (danger == "") danger = "schema"; continue }
       }
       if (!seen || danger == "") continue
       if (danger == "dest") dest = 1
@@ -85,7 +101,7 @@ verdict="$(printf '%s' "$norm" | awk '
 
 case "$verdict" in
   DENY_DEST)
-    deny "Blocked destructive migration command (migrate:fresh/refresh/reset/rollback/install, db:wipe, or an abbreviation of one). These drop or rewrite data and are never run automatically here; a human must run it deliberately if truly required." ;;
+    deny "Blocked destructive database command (migrate:* / schema:dump variants / db:wipe, including Symfony abbreviations). These drop or rewrite data and are never run automatically here; a human must run it deliberately if truly required." ;;
   DENY_MIGRATE)
     deny "Blocked unsafe migration. Only run migrations when explicitly requested, against SQLite only and non-interactively: php artisan migrate --database=sqlite --no-interaction. Each chained artisan call must carry the flags itself, and no non-sqlite --database is allowed." ;;
   DENY_SCHEMA)

--- a/.claude/hooks/block-dangerous-artisan.sh
+++ b/.claude/hooks/block-dangerous-artisan.sh
@@ -7,17 +7,26 @@
 # so the agent can retry with the only permitted form:
 #   php artisan migrate --database=sqlite --no-interaction
 #
-# Design: join line continuations, normalize quotes, split into command segments
-# on shell separators, drop redirections (keeping the surviving args), then check
-# each artisan segment against its OWN flags. Destructive subcommands — migrate:*,
-# schema:dump, db:wipe, and Symfony namespace/command abbreviations of them
-# (migr:f, d:wi, schem:du, ...) — are always denied; only a plain `migrate` with
-# --database=sqlite --no-interaction (no conflicting --database) is allowed.
+# Design: join line continuations, splice quotes out of words (shell semantics),
+# strip word-internal backslash escapes, split into command segments on shell
+# separators, drop redirections (keeping the surviving args), stop at comments,
+# then check each artisan segment against its OWN flags. Destructive subcommands
+# — migrate:* (incl. migrate:status: read-only, but blocked fail-closed to keep
+# abbreviation handling simple; use `php artisan migrate --pretend` or ask a
+# human), schema:dump (unless --database=sqlite and no --prune), db:wipe, and
+# Symfony namespace/command abbreviations of them (migr:f, d:wi, schem:du, ...)
+# — are denied; only `migrate` with --database=sqlite and --no-interaction (or
+# Symfony's global -n short flag, also in clusters like -qn) and no conflicting
+# --database is allowed. A `DB_*=` environment assignment prefixing an artisan
+# DB command is denied (it can silently retarget the connection/path that the
+# flags appear to pin). `--help` / `-h` / a leading `help` subcommand make the
+# segment safe: Symfony renders help instead of executing.
 #
 # This is defense-in-depth for a cooperative agent, not a sandbox: runtime
-# indirection (eval, base64, $(...), env-var assembly) can still reach the shell
-# and is intentionally out of scope — the documented rule + human oversight
-# remain the primary guard.
+# indirection (eval, base64|sh, $(...) producing the command, env-var-stored
+# command bodies, xargs feeding args) can still reach the shell and is
+# intentionally out of scope — the documented rule + human oversight remain
+# the primary guard.
 set -euo pipefail
 
 payload="$(cat || true)"
@@ -34,39 +43,50 @@ deny() {
   exit 0
 }
 
-# Join backslash-newline continuations (bash removes them before tokenizing),
-# then normalize quotes so 'migrate' / --database "mysql" are seen like bare forms.
+# 1) Join backslash-newline continuations (bash removes them before tokenizing).
+# 2) Strip remaining backslashes: outside quotes bash deletes them, so
+#    mi\grate:fresh tokenizes as migrate:fresh.
+# 3) Remove quote characters entirely (NOT replace with space): quotes splice
+#    into the surrounding word, so mi'grate:fresh' is one word migrate:fresh
+#    and --database="sqlite" is --database=sqlite.
 norm="${command//\\$'\n'/ }"
-norm="${norm//\'/ }"
-norm="${norm//\"/ }"
+norm="${norm//\\/}"
+norm="${norm//\'/}"
+norm="${norm//\"/}"
 
 verdict="$(printf '%s' "$norm" | awk '
   { all = all $0 "\n" }
   END {
     # Segment on shell separators / subshells (NOT redirections — their trailing
-    # args still belong to the same command and must be validated).
+    # args still belong to the same command and must be validated). & also
+    # splits &&, &>, 2>&1 harmlessly.
     gsub(/\$\(/, "\n", all)
     gsub(/[;|&()`]/, "\n", all)
     nseg = split(all, segs, "\n")
 
-    dest = 0; bad_migrate = 0; bad_schema = 0
+    dest = 0; bad_migrate = 0; bad_schema = 0; bad_env = 0
 
     for (s = 1; s <= nseg; s++) {
-      m = split(segs[s], tok, /[ \t]+/)
+      m = split(segs[s], tok, /[ \t\r]+/)
       seen = 0; danger = ""; sqlite = 0; nonsqlite = 0; nointer = 0; prune = 0
-      expectdb = 0; skipnext = 0
+      expectdb = 0; skipnext = 0; envdb = 0; helpsafe = 0
       for (i = 1; i <= m; i++) {
         t = tok[i]
         if (t == "") continue
+        # Comment: rest of the (already separator-split) text is not executed.
+        if (t ~ /^#/) break
         if (skipnext) { skipnext = 0; continue }
         # Redirections: drop the operator (and a detached target) but keep the rest.
         if (t ~ /^[0-9]*(>>|<<|>|<)/) {
           if (t ~ /^[0-9]*(>>|<<|>|<)$/) skipnext = 1
           continue
         }
+        # Leading DB_* environment assignment (only valid before the command
+        # word) can retarget the connection or the sqlite file path.
+        if (!seen && t ~ /^DB_[A-Za-z0-9_]*=/) { envdb = 1; continue }
         if (t == "artisan" || t ~ /\/artisan$/) { seen = 1; continue }
         if (!seen) continue
-        # A bare `--database` expects a value, but if the next token is actually a
+        # A bare --database expects a value, but if the next token is actually a
         # dangerous subcommand, classify it instead of swallowing it as the value.
         if (expectdb) {
           expectdb = 0
@@ -75,7 +95,12 @@ verdict="$(printf '%s' "$norm" | awk '
             continue
           }
         }
+        # Symfony renders help instead of running the command.
+        if (t == "--help" || t == "-h") { helpsafe = 1; continue }
+        if (t == "help" && danger == "") { helpsafe = 1; continue }
         if (t == "--no-interaction") { nointer = 1; continue }
+        # Short-option cluster: Symfony global -n == --no-interaction (also -qn).
+        if (t ~ /^-[A-Za-z]+$/) { if (t ~ /n/) nointer = 1; continue }
         if (t == "--prune") { prune = 1; continue }
         if (t ~ /^--database=/) { v = substr(t, 12); if (v == "sqlite") sqlite = 1; else nonsqlite = 1; continue }
         if (t == "--database") { expectdb = 1; continue }
@@ -87,12 +112,15 @@ verdict="$(printf '%s' "$norm" | awk '
         if (t ~ /^sc[a-z]*:d/) { if (danger == "") danger = "schema"; continue }
       }
       if (!seen || danger == "") continue
+      if (helpsafe) continue
+      if (envdb) { bad_env = 1; continue }
       if (danger == "dest") dest = 1
       else if (danger == "migrate") { if (!(sqlite && !nonsqlite && nointer)) bad_migrate = 1 }
       else if (danger == "schema") { if (!(sqlite && !nonsqlite && !prune)) bad_schema = 1 }
     }
 
     if (dest) print "DENY_DEST"
+    else if (bad_env) print "DENY_ENV"
     else if (bad_migrate) print "DENY_MIGRATE"
     else if (bad_schema) print "DENY_SCHEMA"
     else print "OK"
@@ -102,6 +130,8 @@ verdict="$(printf '%s' "$norm" | awk '
 case "$verdict" in
   DENY_DEST)
     deny "Blocked destructive database command (migrate:* / schema:dump variants / db:wipe, including Symfony abbreviations). These drop or rewrite data and are never run automatically here; a human must run it deliberately if truly required." ;;
+  DENY_ENV)
+    deny "Blocked DB_* environment override on a database command (e.g. DB_CONNECTION=... php artisan migrate). The env assignment can silently retarget the connection or sqlite path. Run it without the DB_* prefix: php artisan migrate --database=sqlite --no-interaction." ;;
   DENY_MIGRATE)
     deny "Blocked unsafe migration. Only run migrations when explicitly requested, against SQLite only and non-interactively: php artisan migrate --database=sqlite --no-interaction. Each chained artisan call must carry the flags itself, and no non-sqlite --database is allowed." ;;
   DENY_SCHEMA)

--- a/.claude/hooks/block-dangerous-artisan.sh
+++ b/.claude/hooks/block-dangerous-artisan.sh
@@ -101,7 +101,8 @@ verdict="$(printf '%s' "$norm" | awk '
         if (t == "--no-interaction") { nointer = 1; continue }
         # Short-option cluster: Symfony global -n == --no-interaction (also -qn).
         if (t ~ /^-[A-Za-z]+$/) { if (t ~ /n/) nointer = 1; continue }
-        if (t == "--prune") { prune = 1; continue }
+        # --prune and its Symfony option abbreviations (--prun, --pru).
+        if (t ~ /^--pru/) { prune = 1; continue }
         if (t ~ /^--database=/) { v = substr(t, 12); if (v == "sqlite") sqlite = 1; else nonsqlite = 1; continue }
         if (t == "--database") { expectdb = 1; continue }
         # Destructive: migrate namespace (migrate:* incl. abbrev migr:f) or db:wipe

--- a/.claude/hooks/block-dangerous-artisan.sh
+++ b/.claude/hooks/block-dangerous-artisan.sh
@@ -6,9 +6,18 @@
 # tool call (PreToolUse permissionDecision=deny) rather than halting the session,
 # so the agent can retry with the only permitted form:
 #   php artisan migrate --database=sqlite --no-interaction
-# Destructive variants (migrate:fresh/refresh/reset/rollback, db:wipe) and
-# schema:dump --prune are never allowed here. This is defense-in-depth, not a
-# sandbox: the documented rules + human oversight remain the primary guard.
+#
+# Design: normalize quotes, split the command into segments on shell separators
+# and redirections, then validate EACH artisan segment against its OWN flags.
+# Any migrate:* / schema:d* / db:wi* subcommand (including Symfony command-prefix
+# abbreviations such as migrate:ref, schema:du, db:wi) is treated as destructive
+# and always denied; only a plain `migrate` with --database=sqlite and
+# --no-interaction (and no conflicting --database) is allowed.
+#
+# This is defense-in-depth for a cooperative agent, not a sandbox: indirection
+# such as eval, base64, $(...), or env-var assembly can still reach the shell and
+# is intentionally out of scope — the documented rule + human oversight remain
+# the primary guard.
 set -euo pipefail
 
 payload="$(cat || true)"
@@ -25,63 +34,62 @@ deny() {
   exit 0
 }
 
-# Bash strips quotes before argv reaches artisan, so normalize quotes to spaces;
-# this exposes quoted forms like 'migrate' or --database "mysql".
+# Bash strips quotes before argv reaches artisan; normalize them to spaces so
+# quoted forms ('migrate', --database "mysql") are seen the same as bare ones.
 norm="${command//\'/ }"
 norm="${norm//\"/ }"
 
-# Tokenize and classify any Artisan subcommand that appears after an `artisan`
-# token (resetting at shell separators). Scanning every following token catches
-# space-separated global option values (e.g. `--env production migrate`) that a
-# positional regex misses, and quoted subcommands once quotes are normalized.
-read -r mig dest dump < <(printf '%s\n' "$norm" | awk '
-  BEGIN { seen=0; mig=0; dest=0; dump=0 }
-  {
-    for (i=1; i<=NF; i++) {
-      t=$i
-      if (t=="&&"||t=="||"||t==";"||t=="|"||t=="&") { seen=0; continue }
-      if (t=="artisan" || t ~ /\/artisan$/) { seen=1; continue }
-      if (seen) {
-        if (t=="migrate") mig=1
-        else if (t=="migrate:fresh"||t=="migrate:refresh"||t=="migrate:reset"||t=="migrate:rollback"||t=="db:wipe") dest=1
-        else if (t=="schema:dump") dump=1
+verdict="$(printf '%s' "$norm" | awk '
+  { all = all $0 "\n" }
+  END {
+    # Split into command segments on shell separators / redirections / subshells
+    # so each artisan call is validated with only its own options.
+    gsub(/\$\(/, "\n", all)
+    gsub(/[;|&<>()`]/, "\n", all)
+    nseg = split(all, segs, "\n")
+
+    dest = 0; bad_migrate = 0; bad_schema = 0
+
+    for (s = 1; s <= nseg; s++) {
+      m = split(segs[s], tok, /[ \t]+/)
+      seen = 0; danger = ""; sqlite = 0; nonsqlite = 0; nointer = 0; prune = 0; expectdb = 0
+      for (i = 1; i <= m; i++) {
+        t = tok[i]
+        if (t == "") continue
+        if (t == "artisan" || t ~ /\/artisan$/) { seen = 1; continue }
+        if (!seen) continue
+        if (expectdb) { if (t == "sqlite") sqlite = 1; else nonsqlite = 1; expectdb = 0; continue }
+        if (t == "--no-interaction") { nointer = 1; continue }
+        if (t == "--prune") { prune = 1; continue }
+        if (t ~ /^--database=/) { v = substr(t, 12); if (v == "sqlite") sqlite = 1; else nonsqlite = 1; continue }
+        if (t == "--database") { expectdb = 1; continue }
+        # Destructive: any migrate:* subcommand, or db:wipe (and its abbreviations).
+        if (t ~ /^migrate:/ || t ~ /^db:wi/) { danger = "dest"; continue }
+        # Plain migrate (the only form that can be allowed).
+        if (t == "migrate") { if (danger == "") danger = "migrate"; continue }
+        # schema:dump and its abbreviations (schema:d, schema:du, ...).
+        if (t ~ /^schema:d/) { if (danger == "") danger = "schema"; continue }
       }
+      if (!seen || danger == "") continue
+      if (danger == "dest") dest = 1
+      else if (danger == "migrate") { if (!(sqlite && !nonsqlite && nointer)) bad_migrate = 1 }
+      else if (danger == "schema") { if (!(sqlite && !nonsqlite && !prune)) bad_schema = 1 }
     }
+
+    if (dest) print "DENY_DEST"
+    else if (bad_migrate) print "DENY_MIGRATE"
+    else if (bad_schema) print "DENY_SCHEMA"
+    else print "OK"
   }
-  END { print mig, dest, dump }
-')
+')"
 
-if [[ "$mig" == 0 && "$dest" == 0 && "$dump" == 0 ]]; then
-  exit 0
-fi
-
-# Destructive subcommands are never allowed via the agent, even on sqlite.
-if [[ "$dest" == 1 ]]; then
-  deny "Blocked destructive migration command (migrate:fresh/refresh/reset/rollback or db:wipe). These drop or rewrite data and are never run automatically here; a human must run it deliberately if it is truly required."
-fi
-
-# Collect every --database value (handles =value and space value; quotes already
-# normalized) so repeated/conflicting flags cannot smuggle a non-sqlite target.
-has_sqlite_db=false
-has_non_sqlite_db=false
-while IFS= read -r v; do
-  [[ -z "$v" ]] && continue
-  if [[ "$v" == "sqlite" ]]; then has_sqlite_db=true; else has_non_sqlite_db=true; fi
-done < <(printf '%s\n' "$norm" | grep -oE -- '--database[= ]+[^ ]+' | sed -E 's/^--database[= ]+//' || true)
-
-no_interaction=false
-[[ "$norm" == *"--no-interaction"* ]] && no_interaction=true
-
-if [[ "$mig" == 1 ]]; then
-  if ! $has_sqlite_db || $has_non_sqlite_db || ! $no_interaction; then
-    deny "Blocked unsafe migration. Only run migrations when explicitly requested, against SQLite only and non-interactively: php artisan migrate --database=sqlite --no-interaction. No non-sqlite --database is allowed."
-  fi
-fi
-
-if [[ "$dump" == 1 ]]; then
-  if ! $has_sqlite_db || $has_non_sqlite_db || [[ "$norm" == *"--prune"* ]]; then
-    deny "Blocked unsafe schema dump. Only run when explicitly requested, use --database=sqlite, and never use --prune."
-  fi
-fi
+case "$verdict" in
+  DENY_DEST)
+    deny "Blocked destructive migration command (migrate:fresh/refresh/reset/rollback/install, db:wipe, or an abbreviation of one). These drop or rewrite data and are never run automatically here; a human must run it deliberately if truly required." ;;
+  DENY_MIGRATE)
+    deny "Blocked unsafe migration. Only run migrations when explicitly requested, against SQLite only and non-interactively: php artisan migrate --database=sqlite --no-interaction. Each chained artisan call must carry the flags itself, and no non-sqlite --database is allowed." ;;
+  DENY_SCHEMA)
+    deny "Blocked unsafe schema dump. Only run when explicitly requested, use --database=sqlite, and never use --prune." ;;
+esac
 
 exit 0


### PR DESCRIPTION
## Context

Follow-up to the agent-config bundle PR (already merged). During Codex review, the artisan safety hook went through several hardening rounds; this syncs the final **segment-based** implementation into this repo so all repos carry the identical, most-robust version.

## What changed

Only `.claude/hooks/block-dangerous-artisan.sh`. The hook now:
- splits the command on shell separators/redirections/subshells and validates **each** artisan segment against its **own** flags (closes `migrate; echo`, `migrate>/tmp`, `echo --database=sqlite && php artisan migrate`, and per-chain blessing);
- treats any `migrate:*` / `schema:d*` / `db:wi*` token as destructive, including Symfony command-prefix abbreviations (`migrate:ref`, `schema:du`, `db:wi`) and `migrate:install`;
- uses the PreToolUse `permissionDecision: deny` shape (denies the single Bash call, doesn't halt the session).

Defense-in-depth for a cooperative agent; runtime indirection (eval/base64/$()/env) is out of scope. Verified with a 20-case test matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)