### PR TITLE
Upgrade auth-laravel to v0.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "bherila/auth-laravel": "^0.4",
+        "bherila/auth-laravel": "^0.5",
         "erusev/parsedown": "^1.7",
         "laravel/framework": "^13.0",
         "laravel/tinker": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "179d624181cba0ea7af629fc811709c2",
+    "content-hash": "c04886863049f06b2fb4de3514265fbf",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -159,16 +159,16 @@
         },
         {
             "name": "bherila/auth-laravel",
-            "version": "v0.4.3",
+            "version": "v0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bherila/auth.git",
-                "reference": "d2a78a33685f5e6b35c2b245d3ffc827c682bbb5"
+                "reference": "f5707cd42df725342c5926b6b762199b939a5b56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bherila/auth/zipball/d2a78a33685f5e6b35c2b245d3ffc827c682bbb5",
-                "reference": "d2a78a33685f5e6b35c2b245d3ffc827c682bbb5",
+                "url": "https://api.github.com/repos/bherila/auth/zipball/f5707cd42df725342c5926b6b762199b939a5b56",
+                "reference": "f5707cd42df725342c5926b6b762199b939a5b56",
                 "shasum": ""
             },
             "require": {
@@ -199,12 +199,12 @@
             },
             "autoload": {
                 "psr-4": {
-                    "BWH\\Auth\\": "laravel/src/"
+                    "BWH\\Auth\\": "php/src/"
                 }
             },
             "autoload-dev": {
                 "psr-4": {
-                    "BWH\\Auth\\Tests\\": "laravel/tests/"
+                    "BWH\\Auth\\Tests\\": "php/tests/"
                 }
             },
             "scripts": {
@@ -217,10 +217,10 @@
             ],
             "description": "Shared Laravel authentication services for BWH applications.",
             "support": {
-                "source": "https://github.com/bherila/auth/tree/v0.4.3",
+                "source": "https://github.com/bherila/auth/tree/v0.5.0",
                 "issues": "https://github.com/bherila/auth/issues"
             },
-            "time": "2026-06-08T05:54:47+00:00"
+            "time": "2026-06-14T00:53:17+00:00"
         },
         {
             "name": "brick/math",


### PR DESCRIPTION
## Summary
- Upgrade `bherila/auth-laravel` from `^0.4` to `^0.5` / `v0.5.0`.
- Refresh the lockfile for the published auth v0.5.0 package.

Auth release: https://github.com/bherila/auth/releases/tag/v0.5.0

## Validation
- `composer validate`
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `php artisan test tests/Feature/SharedAuthPackageTest.php tests/Feature/AuthTest.php`