### PR TITLE
Use hosted ARM runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   changes:
     name: Detect changes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     outputs:
       frontend: ${{ steps.filter.outputs.frontend }}
       backend: ${{ steps.filter.outputs.backend }}
@@ -60,7 +60,7 @@ jobs:
     name: Changed-area checks
     needs: changes
     if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.backend == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 12
 
     steps:
@@ -127,7 +127,7 @@ jobs:
     name: CI result
     needs: [changes, test]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Check result
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@v5
@@ -67,7 +67,7 @@ jobs:
             "vendor/bin/paratest --processes=auto"
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: test
     environment: prod
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,6 @@
 
 - Treat `AGENTS.md` as the project contract and `TESTING.AGENTS.md` as the validation contract.
 - Keep private workstation preferences out of committed files; use a local, gitignored override if needed.
-- Because this repo currently lacks a PR CI workflow, run the relevant `TESTING.AGENTS.md` gate before pushing or merging.
+- PR CI runs changed-area checks; also run the relevant `TESTING.AGENTS.md` gate locally before pushing or merging.
 - Do not run migrations or schema dumps unless the user explicitly asks. The committed hook also blocks unsafe forms of those commands.
 - Prefer `gh` CLI for GitHub work and fully-qualified references such as `bherila/spgp-laravel#123`.


### PR DESCRIPTION
## What changed

- Move ordinary GitHub-hosted CI, release, and deployment jobs from `ubuntu-latest` to the standard `ubuntu-24.04-arm` runner.
- Keep Copilot cloud-agent setup on x64 where present because GitHub currently requires an Ubuntu x64 or Windows x64 runner for that integration.

## Why

The ARM runner provides the same standard private-repository capacity for these PHP and Node workflows at a lower hosted-runner rate, while also exercising ARM compatibility.

## Validation

- Parsed every workflow as YAML.
- Checked the patch for whitespace errors.
- The pull-request workflow will run the project checks on ARM before merge.
